### PR TITLE
Change exclude to ignore for Volto 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "dotenv": "^16.3.2",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
-    "md5": "^2.3.0"
+    "md5": "^2.3.0",
+    "cypress": "13.1.0"
   },
   "resolutions": {
     "react-colorscales": "github:eea/react-colorscales#1.0.2"

--- a/src/AppExtras/index.js
+++ b/src/AppExtras/index.js
@@ -5,7 +5,7 @@ export default function applyConfig(config) {
     ...(config.settings.appExtras || []),
     {
       match: '*',
-      exclude: ['/login', '/**/login'],
+      ignore: ['/login', '/**/login'],
       component: Jupyter,
     },
   ];

--- a/src/AppExtras/index.js
+++ b/src/AppExtras/index.js
@@ -6,6 +6,7 @@ export default function applyConfig(config) {
     {
       match: '*',
       ignore: ['/login', '/**/login'],
+      exclude: ['/login', '/**/login'], //deprecated since Volto-17
       component: Jupyter,
     },
   ];


### PR DESCRIPTION
In the new Volto 17, the "exclude" property of App Extras is called ignore