### PR TITLE
fix(performance): load jsoneditor outside of the main client bundle

### DIFF
--- a/src/helpers/editor.js
+++ b/src/helpers/editor.js
@@ -2,7 +2,11 @@ import { isString } from 'lodash';
 import { toast } from 'react-toastify';
 import { Toast } from '@plone/volto/components';
 
-const jsoneditor = __CLIENT__ && require('jsoneditor');
+import loadable from '@loadable/component';
+
+const LoadableJsonEditor = loadable(() => import('jsoneditor'));
+
+const jsoneditor = __CLIENT__ && LoadableJsonEditor;
 
 export function initEditor({ el, editor, dflt, options, onInit }) {
   if (!jsoneditor) return;


### PR DESCRIPTION
- There is no need to load the jsoneditor file unless we need it when navigation to the edit page and using the editor